### PR TITLE
Update dovecot SSL/TLS configuration

### DIFF
--- a/dovecot/conf/dovecot.conf
+++ b/dovecot/conf/dovecot.conf
@@ -57,6 +57,8 @@ namespace inbox {
 ssl = yes
 ssl_cert = </certs/cert.pem
 ssl_key = </certs/key.pem
+ssl_protocols=!SSLv3 !SSLv2
+ssl_cipher_list=TLSv1+HIGH !SSLv2 !RC4 !aNULL !eNULL !3DES @STRENGTH
 
 ###############
 # Authentication


### PR DESCRIPTION
Ensure that RC4 and SSLv3 is not used. This is based off mailinabox project settings, while not the most ideal settings this improves the configuration from what it is currently.