### PR TITLE
Allow admin creation after initial setup

### DIFF
--- a/admin/manage.py
+++ b/admin/manage.py
@@ -21,14 +21,16 @@ def initdb():
 def admin(localpart, domain_name, password):
     """ Create an admin user
     """
-    domain = models.Domain(name=domain_name)
+    domain = models.Domain.query.get(domain_name)
+    if not domain:
+        domain = models.Domain(name=domain_name)
+        db.session.add(domain)
     user = models.User(
         localpart=localpart,
         domain=domain,
         global_admin=True,
         password=hash.sha512_crypt.encrypt(password)
     )
-    db.session.add(domain)
     db.session.add(user)
     db.session.commit()
 


### PR DESCRIPTION
This PR allows running `docker-compose run admin python manage.py admin admin example.com admin` without crashing.

The issue was that after the first run of this command, if you delete your admin user by mistake, running this command again will crash:

```py
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: domain.name [SQL: 'INSERT INTO domain (created_at, updated_at, comment, name, max_users, max_aliases) VALUES (?, ?, ?, ?, ?, ?)'] [parameters: ('2016-09-09', None, None, 'example.com', 0, 0)]
```

So, I deleted my own account- it was the only admin account. The fix I propose here is what I used to recreate my deleted admin account.