### PR TITLE
Default message_size_limit to 50MB

### DIFF
--- a/.env
+++ b/.env
@@ -49,6 +49,10 @@ EXPOSE_ADMIN=no
 # Mail settings
 ###################################
 
+# Message size limit in bytes
+# Default: accept messages up to 50MB
+MESSAGE_SIZE_LIMIT = 50000000
+
 # Networks granted relay permissions, make sure that you include your Docker
 # internal network (default to 172.17.0.0/16)
 RELAYNETS=172.16.0.0/12

--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -7,6 +7,9 @@ mydomain = {{ DOMAIN }}
 myhostname = {{ HOSTNAME }}
 myorigin = $mydomain
 
+# Message size limit
+message_size_limit = {{ MESSAGE_SIZE_LIMIT }}
+
 # Relayed networks
 mynetworks = 127.0.0.1/32 [::1]/128 {{ RELAYNETS }}
 


### PR DESCRIPTION
Add MESSAGE_SIZE_LIMIT variable in .env to allow setting the message size limit for postfix.

The current (default) message size limit of postfix is `10240000` bytes, or roughly 10MB.